### PR TITLE
Add option not to sort in writeAsJson

### DIFF
--- a/packages/util-file/README.md
+++ b/packages/util-file/README.md
@@ -97,8 +97,8 @@ tryExample().catch((err) => console.error(err))
   - [.readAsJson(filename)](./doc/api/api.md#module_@the-/util-file.readAsJson)
   - [.readAsJsonSync(filename)](./doc/api/api.md#module_@the-/util-file.readAsJsonSync)
   - [.statSync(filename)](./doc/api/api.md#module_@the-/util-file.statSync)
-  - [.writeAsJsonSync(filename,data)](./doc/api/api.md#module_@the-/util-file.writeAsJsonSync)
-  - [.writeAsJsonSync(filename,data)](./doc/api/api.md#module_@the-/util-file.writeAsJsonSync)
+  - [.writeAsJson(filename,data,options)](./doc/api/api.md#module_@the-/util-file.writeAsJson)
+  - [.writeAsJsonSync(filename,data,options)](./doc/api/api.md#module_@the-/util-file.writeAsJsonSync)
 - module.module:@the-/util-file
   - [.delSync(filename)](./doc/api/api.md#module.module_@the-/util-file.delSync)
 

--- a/packages/util-file/doc/api/api.md
+++ b/packages/util-file/doc/api/api.md
@@ -15,8 +15,8 @@ File utility for the-framework
     * [.readAsJson(filename)](#module_@the-/util-file.readAsJson) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.readAsJsonSync(filename)](#module_@the-/util-file.readAsJsonSync) ⇒ <code>Object</code>
     * [.statSync(filename)](#module_@the-/util-file.statSync)
-    * [.writeAsJsonSync(filename, data)](#module_@the-/util-file.writeAsJsonSync) ⇒ <code>Promise</code>
-    * [.writeAsJsonSync(filename, data)](#module_@the-/util-file.writeAsJsonSync)
+    * [.writeAsJson(filename, data, [options])](#module_@the-/util-file.writeAsJson) ⇒ <code>Promise</code>
+    * [.writeAsJsonSync(filename, data, [options])](#module_@the-/util-file.writeAsJsonSync)
 
 <a name="module_@the-/util-file.copyAsJsonSync"></a>
 
@@ -77,23 +77,27 @@ Read as json
 | --- | --- |
 | filename | <code>string</code> | 
 
-<a name="module_@the-/util-file.writeAsJsonSync"></a>
+<a name="module_@the-/util-file.writeAsJson"></a>
 
-### utilFile.writeAsJsonSync(filename, data) ⇒ <code>Promise</code>
+### utilFile.writeAsJson(filename, data, [options]) ⇒ <code>Promise</code>
 **Kind**: static method of [<code>@the-/util-file</code>](#module_@the-/util-file)  
 
-| Param | Type |
-| --- | --- |
-| filename | <code>string</code> | 
-| data | <code>Object</code> | 
+| Param | Type | Default |
+| --- | --- | --- |
+| filename | <code>string</code> |  | 
+| data | <code>Object</code> |  | 
+| [options] | <code>Object</code> |  | 
+| [options.sort] | <code>boolean</code> | <code>true</code> | 
 
 <a name="module_@the-/util-file.writeAsJsonSync"></a>
 
-### utilFile.writeAsJsonSync(filename, data)
+### utilFile.writeAsJsonSync(filename, data, [options])
 **Kind**: static method of [<code>@the-/util-file</code>](#module_@the-/util-file)  
 
-| Param | Type |
-| --- | --- |
-| filename | <code>string</code> | 
-| data | <code>Object</code> | 
+| Param | Type | Default |
+| --- | --- | --- |
+| filename | <code>string</code> |  | 
+| data | <code>Object</code> |  | 
+| [options] | <code>Object</code> |  | 
+| [options.sort] | <code>boolean</code> | <code>true</code> | 
 

--- a/packages/util-file/doc/api/jsdoc.json
+++ b/packages/util-file/doc/api/jsdoc.json
@@ -230,9 +230,9 @@
     "order": 7
   },
   {
-    "id": "module:@the-/util-file.writeAsJsonSync",
-    "longname": "module:@the-/util-file.writeAsJsonSync",
-    "name": "writeAsJsonSync",
+    "id": "module:@the-/util-file.writeAsJson",
+    "longname": "module:@the-/util-file.writeAsJson",
+    "name": "writeAsJson",
     "kind": "function",
     "scope": "static",
     "memberof": "module:@the-/util-file",
@@ -252,6 +252,25 @@
           ]
         },
         "name": "data"
+      },
+      {
+        "type": {
+          "names": [
+            "Object"
+          ]
+        },
+        "optional": true,
+        "name": "options"
+      },
+      {
+        "type": {
+          "names": [
+            "boolean"
+          ]
+        },
+        "optional": true,
+        "defaultvalue": true,
+        "name": "options.sort"
       }
     ],
     "returns": [
@@ -293,6 +312,25 @@
           ]
         },
         "name": "data"
+      },
+      {
+        "type": {
+          "names": [
+            "Object"
+          ]
+        },
+        "optional": true,
+        "name": "options"
+      },
+      {
+        "type": {
+          "names": [
+            "boolean"
+          ]
+        },
+        "optional": true,
+        "defaultvalue": true,
+        "name": "options.sort"
       }
     ],
     "meta": {

--- a/packages/util-file/lib/writeAsJson.js
+++ b/packages/util-file/lib/writeAsJson.js
@@ -1,8 +1,10 @@
 /**
  * @memberof module:@the-/util-file
- * @function writeAsJsonSync
+ * @function writeAsJson
  * @param {string} filename
  * @param {Object} data
+ * @param {Object} [options]
+ * @param {boolean} [options.sort=true]
  * @returns {Promise}
  */
 'use strict'
@@ -14,10 +16,13 @@ const { EOL } = require('os')
 const path = require('path')
 const isJSON5File = require('./isJSON5File')
 
-/** @lends module:@the-/util-file.writeAsJsonSync */
-async function writeAsJsonSync(filename, data) {
+/** @lends module:@the-/util-file.writeAsJson */
+async function writeAsJson(filename, data, options = {}) {
   await mkdirpAsync(path.dirname(filename))
-  data = sortProperties(data)
+  const { sort = true } = options
+  if (sort) {
+    data = sortProperties(data)
+  }
   const isJSON5 = isJSON5File(filename)
   const content = isJSON5
     ? JSON5.stringify(data, null, 2) + EOL
@@ -25,4 +30,4 @@ async function writeAsJsonSync(filename, data) {
   await writeFileAsync(filename, content)
 }
 
-module.exports = writeAsJsonSync
+module.exports = writeAsJson

--- a/packages/util-file/lib/writeAsJsonSync.js
+++ b/packages/util-file/lib/writeAsJsonSync.js
@@ -3,6 +3,8 @@
  * @function writeAsJsonSync
  * @param {string} filename
  * @param {Object} data
+ * @param {Object} [options]
+ * @param {boolean} [options.sort=true]
  */
 'use strict'
 
@@ -15,9 +17,12 @@ const path = require('path')
 const isJSON5File = require('./isJSON5File')
 
 /** @lends module:@the-/util-file.writeAsJsonSync */
-function writeAsJsonSync(filename, data) {
+function writeAsJsonSync(filename, data, options = {}) {
   mkdirp.sync(path.dirname(filename))
-  data = sortProperties(data)
+  const { sort = true } = options
+  if (sort) {
+    data = sortProperties(data)
+  }
   const isJSON5 = isJSON5File(filename)
   const content = isJSON5
     ? JSON5.stringify(data, null, 2) + EOL


### PR DESCRIPTION
`writeAsJson()` にキーの sort をしないオプションを追加した。詳細は、

+ options = {} を第三引数に渡し
+ options.sort がデフォルトで true になるようにした

ついでに関数名の修正： `writeAsJson` であるべき関数名が `writeAsJsonSync ` になっていたのを修正