### PR TITLE
MySQL の DATE 型をミリ秒まで保存するようにした

### DIFF
--- a/packages/driver-sequelize/lib/modeling/defineModel.js
+++ b/packages/driver-sequelize/lib/modeling/defineModel.js
@@ -22,7 +22,7 @@ function defineModel(sequelize, resourceName, schema) {
       allowNull: false,
       comment: 'Updated date',
       defaultValue: () => new Date(),
-      type: Sequelize.DATE,
+      type: Sequelize.DATE(3),
     },
     [MetaColumnNames.$$num]: {
       allowNull: false,

--- a/packages/driver-sequelize/lib/modeling/defineModelColumn.js
+++ b/packages/driver-sequelize/lib/modeling/defineModelColumn.js
@@ -32,7 +32,7 @@ function defineModelColumn(propertyName, def = {}) {
     case BOOLEAN:
       return { ...base, type: Sequelize.BOOLEAN }
     case DATE:
-      return { ...base, type: Sequelize.DATE }
+      return { ...base, type: Sequelize.DATE(3) }
     case ENTITY:
     case REF:
       return { ...base, type: Sequelize.STRING(128) }

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -581,6 +581,42 @@ describe('the-driver-sequelize', function() {
     await driver.drop('A')
     await driver.close()
   })
+  it('mysql DATE type should support fractional seconds', async () => {
+    const DB_ROOT_USER = 'root'
+    const DB_ROOT_PASSWORD = 'root'
+    const DB_USER = 'hoge'
+    const DB_PASSWORD = 'fuge'
+    const DATABASE = 'the_driver_sequelize_test'
+
+    await resetMysqlDatabase(DB_ROOT_USER, DB_ROOT_PASSWORD, {
+      database: DATABASE,
+      password: DB_PASSWORD,
+      username: DB_USER,
+    })
+    const driver = new TheDriverSequelize({
+      database: DATABASE,
+      dialect: 'mysql',
+      password: DB_PASSWORD,
+      username: DB_USER,
+    })
+    driver.define('Date', {
+      x: { type: NUMBER },
+      y: { type: NUMBER },
+      z: { maxLength: 1024, type: STRING },
+      date: { type: DATE },
+    })
+
+    const { date: dateA } = await driver.create('Date', {
+      date: new Date('2019-01-01T00:00:00.000Z'),
+    })
+    const { date: dateB } = await driver.create('Date', {
+      date: new Date('2019-01-01T00:00:00.100Z'),
+    })
+    ok(dateA.getTime() < dateB.getTime())
+
+    await driver.drop('Date')
+    await driver.close()
+  })
   it('Multiple entity', async () => {
     const storage = `${__dirname}/../tmp/multiple-entity.db`
     await unlinkAsync(storage).catch(() => null)


### PR DESCRIPTION
From https://sequelize.org/v5/manual/data-types.html

```
Sequelize.DATE                        // DATETIME for mysql / sqlite, TIMESTAMP WITH TIME ZONE for postgres
Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision
```

Sequelize で DATE 型を指定するとき、デフォルトでは「秒」までが保存されるが、JavaScript の DATE 型はミリ秒まであるため、それに合わせてミリ秒まで保存するよう型を変更した。

テストケースを一つ追加した。このテストケースはDATE型の変更前は失敗し、変更後に成功する例である。