### PR TITLE
@the-/lock のエラー時の挙動を修正した

### DIFF
--- a/packages/lock/lib/TheLock.js
+++ b/packages/lock/lib/TheLock.js
@@ -14,8 +14,11 @@ function TheLock() {
      * @returns {Promise}
      */
     async acquire(key, task) {
-      await locks[key]
-      const promise = Promise.resolve(locks[key]).then(async () => task())
+      const promise = Promise.resolve(locks[key])
+        .catch(() => {
+          // 前回の promise 返却時にエラーハンドリングしているはず
+        })
+        .finally(async () => task())
       locks[key] = promise
       return promise
     },

--- a/packages/lock/test/TheLockTest.js
+++ b/packages/lock/test/TheLockTest.js
@@ -57,6 +57,24 @@ describe('the-lock', () => {
     }
     await Promise.all(promises)
   })
+
+  it('Releases lock even when rejected', async () => {
+    const lock = TheLock()
+    let error = null
+    try {
+      await lock.acquire('k1', async () => {
+        throw new Error('error')
+      })
+    } catch (e) {
+      error = e
+    }
+    ok(error)
+    let called = false
+    await lock.acquire('k1', async () => {
+      called = true
+    })
+    equal(called, true)
+  })
 })
 
 /* global describe, before, after, it */

--- a/packages/lock/test/TheLockTest.js
+++ b/packages/lock/test/TheLockTest.js
@@ -6,7 +6,7 @@
 
 const asleep = require('asleep')
 const {
-  strict: { equal, ok },
+  strict: { deepEqual, equal, ok },
 } = require('assert')
 const TheLock = require('../lib/TheLock')
 
@@ -48,18 +48,27 @@ describe('the-lock', () => {
     const lock = TheLock()
     await lock.acquire('k1', () => {})
     const promises = []
+    const indexes = []
     for (let i = 0; i < 100; i++) {
       promises.push(
         lock.acquire('k1', async () => {
           await asleep(2)
+          indexes.push(i)
         }),
       )
     }
     await Promise.all(promises)
+    deepEqual(
+      indexes,
+      Array.from({ length: 100 }).map((_, i) => i),
+    )
   })
 
   it('Releases lock even when rejected', async () => {
     const lock = TheLock()
+    void lock.acquire('k1', async () => {
+      await asleep(1)
+    })
     let error = null
     try {
       await lock.acquire('k1', async () => {

--- a/packages/lock/test/TheLockTest.js
+++ b/packages/lock/test/TheLockTest.js
@@ -52,7 +52,7 @@ describe('the-lock', () => {
     for (let i = 0; i < 100; i++) {
       promises.push(
         lock.acquire('k1', async () => {
-          await asleep(2)
+          await asleep(Math.random() * 10)
           indexes.push(i)
         }),
       )


### PR DESCRIPTION
- Before: `lock.acquire()` に渡す関数が reject すると、以後ずっと reject する
- After: reject する関数を `lock.acquire()` にわたすとそのときだけ reject して以後は正常に使える

詳しくはテストコード参照。
