### PR TITLE
driver-sequelize: 文字列を保存する前に utf8 エンコードするのをやめた

### DIFF
--- a/packages/driver-sequelize/doc/api/api.md
+++ b/packages/driver-sequelize/doc/api/api.md
@@ -5,7 +5,7 @@
 ## @the-/driver-sequelize
 Sequelize driver for the-framework
 
-**Version**: 17.5.1  
+**Version**: 18.0.0  
 **License**: MIT  
 
 * [@the-/driver-sequelize](#module_@the-/driver-sequelize)

--- a/packages/driver-sequelize/doc/api/jsdoc.json
+++ b/packages/driver-sequelize/doc/api/jsdoc.json
@@ -13,7 +13,7 @@
     "name": "@the-/driver-sequelize",
     "order": 2,
     "typicalname": "driverSequelize",
-    "version": "17.5.1"
+    "version": "18.0.0"
   },
   {
     "description": "Define schema",
@@ -23,7 +23,7 @@
     "memberof": "TheDriverSequelize",
     "meta": {
       "filename": "TheDriverSequelize.js",
-      "lineno": 113,
+      "lineno": 116,
       "path": "lib"
     },
     "name": "define",
@@ -67,7 +67,7 @@
     "memberof": "TheDriverSequelize",
     "meta": {
       "filename": "TheDriverSequelize.js",
-      "lineno": 399,
+      "lineno": 411,
       "path": "lib"
     },
     "name": "untilReady",

--- a/packages/driver-sequelize/lib/TheDriverSequelize.js
+++ b/packages/driver-sequelize/lib/TheDriverSequelize.js
@@ -25,8 +25,8 @@ class TheDriverSequelize extends Driver {
   constructor(config = {}) {
     super()
     const {
-      charset = 'utf8',
-      collate = 'utf8_general_ci',
+      charset = 'utf8mb4',
+      collate = 'utf8mb4_unicode_ci',
       database,
       dialect = 'sqlite',
       enableLegacyEncoding = false,

--- a/packages/driver-sequelize/lib/TheDriverSequelize.js
+++ b/packages/driver-sequelize/lib/TheDriverSequelize.js
@@ -29,6 +29,7 @@ class TheDriverSequelize extends Driver {
       collate = 'utf8_general_ci',
       database,
       dialect = 'sqlite',
+      enableLegacyEncoding = false,
       logging = false,
       password,
       storage = `var/db/${database}.db`,
@@ -41,6 +42,7 @@ class TheDriverSequelize extends Driver {
     this.prepareLocks = {}
     this.charset = charset
     this.collate = collate
+    this.enableLegacyEncoding = enableLegacyEncoding
     this._sequelizeArgs = [
       database,
       username,
@@ -70,6 +72,7 @@ class TheDriverSequelize extends Driver {
               where,
             }
           }
+
           return include
         })
     }
@@ -124,7 +127,12 @@ class TheDriverSequelize extends Driver {
     const Model = this.modelFor(resourceName)
     const Schema = this.schemaFor(resourceName)
     const { name: ModelName, rawAttributes: ModelAttributes } = Model
-    return convertInbound(values, { ModelAttributes, ModelName, Schema })
+    return convertInbound(values, {
+      ModelAttributes,
+      ModelName,
+      Schema,
+      enableLegacyEncoding: this.enableLegacyEncoding,
+    })
   }
 
   modelFor(resourceName) {
@@ -149,6 +157,7 @@ class TheDriverSequelize extends Driver {
       ModelName,
       Schema,
       associated,
+      enableLegacyEncoding: this.enableLegacyEncoding,
       outbound: (v) => this.outbound(v.constructor.name, v.dataValues),
       resourceName,
     })
@@ -245,6 +254,7 @@ class TheDriverSequelize extends Driver {
       ModelAttributes,
       ModelName,
       Schema,
+      enableLegacyEncoding: this.enableLegacyEncoding,
     })
     const include = this.includesFor(Model.name, {
       wheres: Object.entries(nestedFilters).reduce((wheres, [k, v]) => {
@@ -260,6 +270,7 @@ class TheDriverSequelize extends Driver {
                 ModelAttributes: associatedModel.rawAttributes,
                 ModelName: associatedModel.name,
                 Schema: this.schemaFor(associatedModel.name),
+                enableLegacyEncoding: this.enableLegacyEncoding,
               },
             ),
           },
@@ -312,6 +323,7 @@ class TheDriverSequelize extends Driver {
     if (!model) {
       return null
     }
+
     return this.outbound(resourceName, model.dataValues)
   }
 

--- a/packages/driver-sequelize/lib/converters/convertInbound.js
+++ b/packages/driver-sequelize/lib/converters/convertInbound.js
@@ -13,7 +13,12 @@ const parseAttributeName = require('../parsing/parseAttributeName')
  * @returns {*}
  */
 function convertInbound(values, options = {}) {
-  const { ModelAttributes = {}, ModelName, Schema } = options
+  const {
+    ModelAttributes = {},
+    ModelName,
+    Schema,
+    enableLegacyEncoding,
+  } = options
   const converted = {
     [MetaColumnNames.$$at]: values.$$at || new Date(),
   }
@@ -37,6 +42,7 @@ function convertInbound(values, options = {}) {
     }
 
     converted[attributeName] = serializer.serialize(v, {
+      enableLegacyEncoding,
       schema: Schema[propertyName],
     })
   }

--- a/packages/driver-sequelize/lib/converters/convertOutbound.js
+++ b/packages/driver-sequelize/lib/converters/convertOutbound.js
@@ -14,7 +14,14 @@ const parseAttributeName = require('../parsing/parseAttributeName')
  * @returns {*}
  */
 function convertOutbound(values, options = {}) {
-  const { ModelName, Schema, associated = [], outbound, resourceName } = options
+  const {
+    ModelName,
+    Schema,
+    associated = [],
+    enableLegacyEncoding,
+    outbound,
+    resourceName,
+  } = options
   const converted = {
     $$as: resourceName,
     $$at: values[MetaColumnNames.$$at],
@@ -45,7 +52,9 @@ function convertOutbound(values, options = {}) {
       continue
     }
 
-    converted[name] = serializer.deserialize(v, def.type)
+    converted[name] = serializer.deserialize(v, def.type, {
+      enableLegacyEncoding,
+    })
   }
   return clayEntity(converted)
 }

--- a/packages/driver-sequelize/lib/helpers/serializer.js
+++ b/packages/driver-sequelize/lib/helpers/serializer.js
@@ -10,7 +10,7 @@ const utf8 = require('utf8')
 const isEmpty = (v) => v === null || typeof v === 'undefined'
 
 exports.serialize = (value, options = {}) => {
-  const { schema = {} } = options
+  const { enableLegacyEncoding = false, schema = {} } = options
   const type = typeOf(value)
   const isMultiple = type !== OBJECT && Array.isArray(value)
   if (isMultiple) {
@@ -38,7 +38,11 @@ exports.serialize = (value, options = {}) => {
         value = String(value).slice(0, maxLength)
       }
 
-      return utf8.encode(String(value))
+      if (enableLegacyEncoding) {
+        return utf8.encode(String(value))
+      } else {
+        return String(value)
+      }
     }
     default: {
       return value
@@ -46,11 +50,13 @@ exports.serialize = (value, options = {}) => {
   }
 }
 
-exports.deserialize = (value, type) => {
+exports.deserialize = (value, type, options = {}) => {
   const isMultiple = type !== OBJECT && Array.isArray(value)
   if (isMultiple) {
     return value.map((value) => exports.serialize(value, type))
   }
+
+  const { enableLegacyEncoding = false } = options
 
   switch (type) {
     case ENTITY:
@@ -61,7 +67,11 @@ exports.deserialize = (value, type) => {
       return String(value)
     }
     case STRING:
-      return isEmpty(value) ? null : utf8.decode(String(value))
+      if (enableLegacyEncoding) {
+        return isEmpty(value) ? null : utf8.decode(String(value))
+      } else {
+        return isEmpty(value) ? null : String(value)
+      }
     default:
       return value
   }

--- a/packages/driver-sequelize/lib/index.js
+++ b/packages/driver-sequelize/lib/index.js
@@ -5,7 +5,7 @@
  * @license MIT
  * @module @the-/driver-sequelize
  * @typicalname driverSequelize
- * @version 17.5.1
+ * @version 18.0.0
  */
 'use strict'
 

--- a/packages/driver-sequelize/lib/parsing/parseFilter.js
+++ b/packages/driver-sequelize/lib/parsing/parseFilter.js
@@ -23,7 +23,12 @@ function parseFilter(filter, options = {}) {
     return filter
   }
 
-  const { ModelAttributes = {}, ModelName, Schema } = options
+  const {
+    ModelAttributes = {},
+    ModelName,
+    Schema,
+    enableLegacyEncoding,
+  } = options
   if (Array.isArray(filter)) {
     return { [Op.or]: filter.map((filter) => parseFilter(filter, options)) }
   }
@@ -71,6 +76,7 @@ function parseFilter(filter, options = {}) {
       }
       default: {
         parsed[parseAttributeName(propertyName)] = serializer.serialize(value, {
+          enableLegacyEncoding,
           schema: Schema[propertyName],
         })
         break

--- a/packages/driver-sequelize/package-lock.json
+++ b/packages/driver-sequelize/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/driver-sequelize",
-  "version": "17.4.0",
+  "version": "18.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/driver-sequelize/package.json
+++ b/packages/driver-sequelize/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/driver-sequelize",
   "description": "Sequelize driver for the-framework",
-  "version": "17.5.1",
+  "version": "18.0.0",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -7,9 +7,9 @@
 const { unlinkAsync } = require('asfs')
 const {
   deepStrictEqual: deepEqual,
+  notStrictEqual: notEqual,
   ok,
   strictEqual: equal,
-  notStrictEqual: notEqual,
 } = require('assert')
 const {
   DataTypes: { DATE, NUMBER, OBJECT, REF, STRING },
@@ -763,8 +763,8 @@ describe('the-driver-sequelize', function () {
     })
     const driverLegacy = new TheDriverSequelize({
       dialect: 'sqlite',
-      storage,
       enableLegacyEncoding: true,
+      storage,
     })
     driver.define('A', {
       text: { type: STRING },

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -108,7 +108,6 @@ describe('the-driver-sequelize', function () {
       const user01 = await driver.create('User', { a: 1 })
       const user01updated = await driver.update('User', user01.id, { b: 2 })
       const user02 = await driver.create('User', { c: 3 })
-      console.log('user01updated', user01updated)
       equal(user01updated.a, 1)
       equal(user01updated.b, 2)
       equal(user02.c, 3)
@@ -678,9 +677,14 @@ describe('the-driver-sequelize', function () {
       equal(list3.entities[0].aId, a1.id)
     }
     {
-      await driver.create('A', {
-        z: 'あいうえお',
-      })
+      await driver.createBulk('A', [
+        {
+          z: 'あいうえお',
+        },
+        {
+          z: '🍣🍺🍣',
+        },
+      ])
       const list = await driver.list('A', {
         filter: {
           z: {
@@ -689,6 +693,14 @@ describe('the-driver-sequelize', function () {
         },
       })
       equal(list.meta.length, 1)
+      const list2 = await driver.list('A', {
+        filter: {
+          z: {
+            $like: '%🍺%',
+          },
+        },
+      })
+      equal(list2.meta.length, 1)
     }
 
     await driver.drop('A')

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -652,7 +652,7 @@ describe('the-driver-sequelize', function () {
       equal(b1One.a.id, a1.id)
       equal(b1One.aId, a1.id)
 
-      const b2 = await driver.create('B', {
+      await driver.create('B', {
         aId: a3.id,
       })
 
@@ -671,6 +671,19 @@ describe('the-driver-sequelize', function () {
       })
       equal(list2.entities[0].aId, a3.id)
       equal(list3.entities[0].aId, a1.id)
+    }
+    {
+      await driver.create('A', {
+        z: 'あいうえお',
+      })
+      const list = await driver.list('A', {
+        filter: {
+          z: {
+            $like: '%う%',
+          },
+        },
+      })
+      equal(list.meta.length, 1)
     }
 
     await driver.drop('A')


### PR DESCRIPTION
https://github.com/realglobe-Inc/hec-eye/issues/4835#issuecomment-697275893 の抜本的解決

## 概要

文字列をDBに保存する前にutf8でエンコードしていた。[元のコミット](https://github.com/realglobe-Inc/clay-driver-sequelize/commit/10e233ae610e1c2f3695db21e74fcf288cb47d98)によると絵文字をサポートするためだったようだが、character set を utf8mb4 にすれば問題なく絵文字を保存できるため不要な処理だった。このエンコードにより以下のようなデメリットがある。

- LIKE 検索ができない
- MySQL の生データを取り出すと文字化けする
- パフォーマンス低下

そのため utf8 のエンコード処理をなくした。

## 変更点

- serializer の中で文字列を utf8 でエンコードする処理をやめた
- 既存データのマイグレーションのため `enableLegacyEncoding` オプションを付けると utf8 エンコードするようにした
- 後方互換性がなくなるのでメジャーバージョンを上げた
- デフォルトの charaset を utf8 から utf8mb4 にした
- テストケースを追加した（変更前のコードではこれらのテストは失敗する）

## TODO

- `@the-/db` も改修する必要がある
- 既存システムのマイグレーションは大変そう

ディスクリプション書きましたー @okunishinishi 