### PR TITLE
Workaround to avoid resize loop error for ResizeObserver

### DIFF
--- a/packages/util-ui/doc/api/api.md
+++ b/packages/util-ui/doc/api/api.md
@@ -24,7 +24,7 @@ module:@the-/util-ui</p>
 ## @the-/util-ui
 Utility for the-components
 
-**Version**: 16.4.1  
+**Version**: 16.4.2  
 **License**: MIT  
 
 * [@the-/util-ui](#module_@the-/util-ui)

--- a/packages/util-ui/doc/api/jsdoc.json
+++ b/packages/util-ui/doc/api/jsdoc.json
@@ -13,7 +13,7 @@
     "name": "@the-/util-ui",
     "order": 6,
     "typicalname": "utilUi",
-    "version": "16.4.1"
+    "version": "16.4.2"
   },
   {
     "description": "Convert base64 data into blob\nmodule:@the-/util-ui",

--- a/packages/util-ui/lib/index.js
+++ b/packages/util-ui/lib/index.js
@@ -5,7 +5,7 @@
  * @license MIT
  * @module @the-/util-ui
  * @typicalname utilUi
- * @version 16.4.1
+ * @version 16.4.2
  */
 'use strict'
 

--- a/packages/util-ui/lib/observeResize.js
+++ b/packages/util-ui/lib/observeResize.js
@@ -19,8 +19,11 @@ function observeResize(elm, handler) {
     return () => {}
   }
 
+  const window = get('window')
   const resizeObserver = new ResizeObserver((entries) => {
-    handler([...entries])
+    window.requestAnimationFrame(() => {
+      handler([...entries])
+    })
   })
   resizeObserver.observe(elm)
   return () => {

--- a/packages/util-ui/package-lock.json
+++ b/packages/util-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/util-ui",
-  "version": "16.4.1",
+  "version": "16.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util-ui/package.json
+++ b/packages/util-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/util-ui",
   "description": "Utility for the-components",
-  "version": "16.4.1",
+  "version": "16.4.2",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",


### PR DESCRIPTION
@okunishinishi 

ResizeObserver で時々発生する Resize Loop Error を抑止するためのワークアラウンドとして requestAnimationFrame() でハンドラーをラップするようにした。

- Resize Loop Error で困る事例 https://github.com/realglobe-Inc/hec-eye/issues/4727
- このエラーは1フレーム以内にResizeObserverに登録されているコールバック関数を処理しきれないと発生する
- このエラーの最小再現コードは https://jsfiddle.net/que_etc/ba1ad26e/ 。コールバック関数内でDOM操作すると発生するようだ
- [stack overflow](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded) で requestAnimationFrame() でラップするワークアラウンドを紹介している人がいた
- 上記の再現コードも requestAnimationFrame() でラップするとエラーが発生しなくなる
