### PR TITLE
ResizeObserverは必ずutil-uiを介して使うようにした

### DIFF
--- a/packages/ui-map/lib/TheMap.jsx
+++ b/packages/ui-map/lib/TheMap.jsx
@@ -213,11 +213,6 @@ const TheMap = React.memo((props) => {
       return
     }
 
-    const ResizeObserver = get('ResizeObserver')
-    if (!ResizeObserver) {
-      return
-    }
-
     const { current: mapElm } = mapElmRef
     const unobserve = observeResize(mapElm, () => {
       mapAccess.invalidate()

--- a/packages/ui-map/lib/TheMap.jsx
+++ b/packages/ui-map/lib/TheMap.jsx
@@ -11,7 +11,6 @@ import {
   newId,
   observeResize,
 } from '@the-/util-ui'
-import { get } from '@the-/window'
 import TileLayer from './classes/TileLayer'
 import MapAccess from './helpers/MapAccess'
 

--- a/packages/ui-map/lib/TheMap.jsx
+++ b/packages/ui-map/lib/TheMap.jsx
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import L from '@okunishinishi/leaflet-shim'
 import { TheSpin } from '@the-/ui-spin'
-import { eventHandlersFor, htmlAttributesFor, newId } from '@the-/util-ui'
+import {
+  eventHandlersFor,
+  htmlAttributesFor,
+  newId,
+  observeResize,
+} from '@the-/util-ui'
 import { get } from '@the-/window'
 import TileLayer from './classes/TileLayer'
 import MapAccess from './helpers/MapAccess'
@@ -214,14 +219,10 @@ const TheMap = React.memo((props) => {
     }
 
     const { current: mapElm } = mapElmRef
-    const resizeObserver = new ResizeObserver(() => {
+    const unobserve = observeResize(mapElm, () => {
       mapAccess.invalidate()
     })
-    resizeObserver.observe(mapElm)
-    return () => {
-      resizeObserver.unobserve(mapElm)
-      resizeObserver.disconnect()
-    }
+    return unobserve
   }, [mapAccess])
 
   const style = { ...props.style, height, width }

--- a/packages/ui-map/package-lock.json
+++ b/packages/ui-map/package-lock.json
@@ -272,14 +272,14 @@
       }
     },
     "@the-/util-ui": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@the-/util-ui/-/util-ui-16.4.1.tgz",
-      "integrity": "sha512-jOJn8h3Zun2gMpM02yahYuqKqmcAkbbZjcOEiubAq+F5bvjTb3EkjhzHaxVPxROfBP6aex4kkrnXgoVEXD055w==",
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@the-/util-ui/-/util-ui-16.4.3.tgz",
+      "integrity": "sha512-p6UKeVbBv84CpccSsF45Gef0bw4Hrij5Hstjd+7Gdq11rWS9B3niSmrPlDQ79IMX7cNjAe2vARtzp4Wbq4kJvg==",
       "requires": {
         "@the-/const-ui": "^15.5.2",
         "bwindow": "^2.0.3",
         "keycode": "^2.2.0",
-        "uuid": "^8.0.0",
+        "uuid": "^8.3.0",
         "video-extensions": "^1.1.0"
       }
     },
@@ -1261,9 +1261,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "value-equal": {
       "version": "1.0.1",

--- a/packages/ui-map/package.json
+++ b/packages/ui-map/package.json
@@ -20,7 +20,7 @@
     "@the-/const-ui": "^15.5.2",
     "@the-/ui-spin": "^16.0.1",
     "@the-/ui-style": "^16.0.2",
-    "@the-/util-ui": "^16.4.1",
+    "@the-/util-ui": "^16.4.3",
     "@the-/window": "^15.8.3",
     "classnames": "^2.2.6",
     "formatcoords": "^1.1.3",

--- a/packages/ui-signature/lib/TheSignature.jsx
+++ b/packages/ui-signature/lib/TheSignature.jsx
@@ -7,6 +7,7 @@ import SignaturePad from 'signature_pad/dist/signature_pad'
 import {
   eventHandlersFor,
   htmlAttributesFor,
+  observeResize,
   stopTouchScrolling,
 } from '@the-/util-ui'
 import { get } from '@the-/window'
@@ -70,13 +71,10 @@ const TheSignature = (props) => {
     const { current: canvas } = canvasRef
     if (!canvas) return
 
-    const ResizeObserver = get('ResizeObserver')
-    const resizeObserver = new ResizeObserver(() => {
+    const unobserve = observeResize(canvas, () => {
       updateCanvasSize()
     })
-    resizeObserver.observe(canvasRef.current)
-
-    return () => resizeObserver.disconnect()
+    return unobserve
   }, [canvasRef, updateCanvasSize])
 
   const reloadPad = useCallback(() => {

--- a/packages/ui-signature/package-lock.json
+++ b/packages/ui-signature/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/ui-signature",
-  "version": "16.0.2",
+  "version": "16.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -238,14 +238,14 @@
       }
     },
     "@the-/util-ui": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@the-/util-ui/-/util-ui-16.4.1.tgz",
-      "integrity": "sha512-jOJn8h3Zun2gMpM02yahYuqKqmcAkbbZjcOEiubAq+F5bvjTb3EkjhzHaxVPxROfBP6aex4kkrnXgoVEXD055w==",
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@the-/util-ui/-/util-ui-16.4.3.tgz",
+      "integrity": "sha512-p6UKeVbBv84CpccSsF45Gef0bw4Hrij5Hstjd+7Gdq11rWS9B3niSmrPlDQ79IMX7cNjAe2vARtzp4Wbq4kJvg==",
       "requires": {
         "@the-/const-ui": "^15.5.2",
         "bwindow": "^2.0.3",
         "keycode": "^2.2.0",
-        "uuid": "^8.0.0",
+        "uuid": "^8.3.0",
         "video-extensions": "^1.1.0"
       },
       "dependencies": {
@@ -1250,9 +1250,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "value-equal": {
       "version": "1.0.1",

--- a/packages/ui-signature/package.json
+++ b/packages/ui-signature/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@the-/ui-style": "^16.0.2",
-    "@the-/util-ui": "^16.4.1",
+    "@the-/util-ui": "^16.4.3",
     "@the-/window": "^15.8.3",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
@okunishinishi 

#44 を他のパッケージにも適用するため、パッケージ内で ResizeObserver が使われている箇所はすべて util-ui の observeResize を使うようにした。以下のパッケージを変更した。

- @the-/ui-map
- @the-/ui-signature

