### PR TITLE
Append file extension to the file captured by TheCamInput

### DIFF
--- a/packages/ui-cam/lib/TheCamInput.jsx
+++ b/packages/ui-cam/lib/TheCamInput.jsx
@@ -63,7 +63,8 @@ const TheCamInput = (props) => {
     try {
       const File = get('File', { strict: true })
       const blob = await media.takePhoto({})
-      const filename = newId({ prefix: 'the-cam-input-value' })
+      const ext = `.${blob.type.split('/').pop()}` // image/* の後半を拡張子にする
+      const filename = newId({ prefix: 'the-cam-input-value' }) + ext
       const file = await convertFile(
         new File([blob], filename, {
           type: blob.type,


### PR DESCRIPTION
TheCamInput で生成される画像ファイル名に拡張子を付けるようにした。Blob の MIME タイプから拡張子を判断する。

- 拡張子の付与はライブラリ側でやったほうがよさそうなのでそうした
- TheCamInput を使用している既存のコード側で気を利かせて拡張子を付けていたりすると、二重に拡張子をつけてしまう影響がある
- Mac Chrome、Mac Safari、iPhone Safari、Android Chrome で動作確認済（.jpeg や .png になる）

