### PR TITLE
isUrlの正規表現パターンを変更

### DIFF
--- a/packages/util-string/README.md
+++ b/packages/util-string/README.md
@@ -81,7 +81,7 @@ tryExample().catch((err) => console.error(err))
 - module:@the-/util-site
 Convert into japanese strings.
 英数字記号は半角、カナは全角へ
-  - [.formatString()](./doc/api/api.md#module_@the-/util-site
+  - [.formatString(src)](./doc/api/api.md#module_@the-/util-site
 Convert into japanese strings.
 英数字記号は半角、カナは全角へ.formatString)
 - module:@the-/util-string

--- a/packages/util-string/doc/api/jsdoc.json
+++ b/packages/util-string/doc/api/jsdoc.json
@@ -195,16 +195,16 @@
     "scope": "static"
   },
   {
-    "id": "module:@the-/util-site\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ.formatString",
+    "id": "module:@the-/util-string\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ.normalizeString",
     "kind": "function",
-    "longname": "module:@the-/util-site\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ.formatString",
-    "memberof": "module:@the-/util-site\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ",
+    "longname": "module:@the-/util-string\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ.normalizeString",
+    "memberof": "module:@the-/util-string\nConvert into japanese strings.\n英数字記号は半角、カナは全角へ",
     "meta": {
       "filename": "normalizeString.js",
       "lineno": 184,
       "path": "lib"
     },
-    "name": "formatString",
+    "name": "normalizeString",
     "order": 6,
     "params": [
       {

--- a/packages/util-string/lib/isUrl.js
+++ b/packages/util-string/lib/isUrl.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const PATTERNS = [/^https?:/, /^data?:/]
+const PATTERNS = [/^https?:\S+$/, /^data:\S+$/]
 
 /**
  * Check if is url

--- a/packages/util-string/package-lock.json
+++ b/packages/util-string/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/util-string",
-  "version": "15.4.13",
+  "version": "15.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/util-string/test/isUrlTest.js
+++ b/packages/util-string/test/isUrlTest.js
@@ -18,6 +18,10 @@ describe('is-url', () => {
     ok(isUrl)
     ok(isUrl('http://example.com'))
     ok(isUrl('https://example.com/foo/bar'))
+    ok(isUrl('data:,Hello%2C%20World!'))
+    ok(!isUrl('http://example.com http://example.jp'))
+    ok(!isUrl('data:,Hello%2C%20World!  '))
+    ok(!isUrl('dat:,Hello%2C%20World!'))
   })
 })
 


### PR DESCRIPTION
`isUrl`の正規表現パターンを`[/^https?:/, /^data?:/]`から、`[/^https?:\S+$/, /^data:\S+$/]`へ変更した。


- `dat:hoge`を受け付けないようになった。
- 空白を含む文字列を受け付けないようになった。(例: `https://hoge  `, `http://example.com https://example.jp`)