### PR TITLE
Fix error that happens when an associated entity is destroyed

### DIFF
--- a/packages/driver-sequelize/lib/TheDriverSequelize.js
+++ b/packages/driver-sequelize/lib/TheDriverSequelize.js
@@ -158,7 +158,8 @@ class TheDriverSequelize extends Driver {
       Schema,
       associated,
       enableLegacyEncoding: this.enableLegacyEncoding,
-      outbound: (v) => this.outbound(v.constructor.name, v.dataValues),
+      outbound: (v) =>
+        v ? this.outbound(v.constructor.name, v.dataValues) : v,
       resourceName,
     })
   }

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -798,7 +798,7 @@ describe('the-driver-sequelize', function () {
     ok(migrated.entities.find(({ text }) => text === en.text))
     ok(migrated.entities.find(({ text }) => text === emoji.text))
   })
-  it('Destroy a entity which has an associate', async () => {
+  it('Destroy an entity which has an associate', async () => {
     const storage = `${__dirname}/../tmp/associate.db`
     await unlinkAsync(storage).catch(() => null)
     const driver = new TheDriverSequelize({

--- a/packages/driver-sequelize/test/TheDriverSequelizeTest.js
+++ b/packages/driver-sequelize/test/TheDriverSequelizeTest.js
@@ -798,6 +798,28 @@ describe('the-driver-sequelize', function () {
     ok(migrated.entities.find(({ text }) => text === en.text))
     ok(migrated.entities.find(({ text }) => text === emoji.text))
   })
+  it('Destroy a entity which has an associate', async () => {
+    const storage = `${__dirname}/../tmp/associate.db`
+    await unlinkAsync(storage).catch(() => null)
+    const driver = new TheDriverSequelize({
+      dialect: 'sqlite',
+      storage,
+    })
+    driver.define('A', {})
+    driver.define('B', {
+      aId: {
+        associate: ['A', { as: 'a' }],
+        type: STRING,
+      },
+    })
+
+    const associated = await driver.create('A', {})
+    await driver.create('B', { aId: associated.id })
+    await driver.destroy('A', associated.id)
+    equal((await driver.list('B')).entities.length, 1)
+
+    await driver.close()
+  })
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
#51 のやり直し

- 修正箇所（outbound）自体は正しかった
- driver-sequelize 側の不具合なのでテストコードはそっちに書いた
- 不具合を再現するテストを書いた
   - 単に associate で参照しているエンティティが削除されると `TypeError: Cannot read property 'constructor' of null` が起きる
   - #51 のテストコードで再現しなかった理由はテスト内の db に memory driver を使っていたから

