### PR TITLE
@the-/server: 接続ステータスを管理するようにした

### DIFF
--- a/packages/server/doc/api/api.md
+++ b/packages/server/doc/api/api.md
@@ -29,7 +29,7 @@
 ## @the-/server
 HTTP/RPC Server of the-framework
 
-**Version**: 17.7.7  
+**Version**: 17.7.8  
 **License**: MIT  
 
 * [@the-/server](#module_@the-/server)

--- a/packages/server/doc/api/api.md
+++ b/packages/server/doc/api/api.md
@@ -8,6 +8,14 @@
 </dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#ClientStatuses">ClientStatuses</a></dt>
+<dd><p>Client connection statuses</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
@@ -399,6 +407,12 @@ Create a TheServer instance
 Alias of [create](#module_@the-/server.create)
 
 **Kind**: static method of [<code>@the-/server</code>](#module_@the-/server)  
+<a name="ClientStatuses"></a>
+
+## ClientStatuses
+Client connection statuses
+
+**Kind**: global constant  
 <a name="IOEvents"></a>
 
 ## IOEvents()

--- a/packages/server/doc/api/jsdoc.json
+++ b/packages/server/doc/api/jsdoc.json
@@ -68,7 +68,7 @@
     "longname": "module:@the-/server.stores.ConnectionStore",
     "memberof": "module:@the-/server.stores.ConnectionStore",
     "name": "ConnectionStore",
-    "order": 41
+    "order": 42
   },
   {
     "description": "Client session store for the-server",
@@ -77,7 +77,7 @@
     "longname": "module:@the-/server.stores.SessionStore",
     "memberof": "module:@the-/server.stores.SessionStore",
     "name": "SessionStore",
-    "order": 44
+    "order": 45
   },
   {
     "description": "Client data store for the-server",
@@ -86,7 +86,22 @@
     "longname": "module:@the-/server.stores.Store",
     "memberof": "module:@the-/server.stores.Store",
     "name": "Store",
-    "order": 46
+    "order": 47
+  },
+  {
+    "description": "Client connection statuses",
+    "id": "ClientStatuses",
+    "kind": "constant",
+    "longname": "ClientStatuses",
+    "meta": {
+      "filename": "ClientStatuses.js",
+      "lineno": 6,
+      "path": "lib/constants"
+    },
+    "name": "ClientStatuses",
+    "order": 16,
+    "params": [],
+    "scope": "global"
   },
   {
     "description": "Events for IO",
@@ -99,7 +114,7 @@
       "path": "lib/constants"
     },
     "name": "IOEvents",
-    "order": 18,
+    "order": 19,
     "scope": "global"
   },
   {
@@ -110,7 +125,7 @@
     "memberof": "TheServer",
     "meta": {
       "filename": "TheServer.js",
-      "lineno": 195,
+      "lineno": 197,
       "path": "lib"
     },
     "name": "info",
@@ -127,7 +142,7 @@
     "memberof": "TheServer",
     "meta": {
       "filename": "TheServer.js",
-      "lineno": 212,
+      "lineno": 214,
       "path": "lib"
     },
     "name": "close",
@@ -164,7 +179,7 @@
     "memberof": "TheServer",
     "meta": {
       "filename": "TheServer.js",
-      "lineno": 238,
+      "lineno": 240,
       "path": "lib"
     },
     "name": "destroyAllSessions",
@@ -191,7 +206,7 @@
     "memberof": "TheServer",
     "meta": {
       "filename": "TheServer.js",
-      "lineno": 251,
+      "lineno": 253,
       "path": "lib"
     },
     "name": "listen",
@@ -231,7 +246,7 @@
       "path": "lib/stores"
     },
     "name": "cleanup",
-    "order": 47,
+    "order": 48,
     "params": [],
     "returns": [
       {
@@ -257,7 +272,7 @@
       "path": "lib/stores"
     },
     "name": "del",
-    "order": 48,
+    "order": 49,
     "params": [
       {
         "type": {
@@ -293,7 +308,7 @@
       "path": "lib/stores"
     },
     "name": "delAll",
-    "order": 49,
+    "order": 50,
     "params": [],
     "returns": [
       {
@@ -319,7 +334,7 @@
       "path": "lib/stores"
     },
     "name": "get",
-    "order": 50,
+    "order": 51,
     "params": [
       {
         "type": {
@@ -355,7 +370,7 @@
       "path": "lib/stores"
     },
     "name": "has",
-    "order": 51,
+    "order": 52,
     "params": [
       {
         "type": {
@@ -391,7 +406,7 @@
       "path": "lib/stores"
     },
     "name": "ids",
-    "order": 52,
+    "order": 53,
     "params": [],
     "returns": [
       {
@@ -417,7 +432,7 @@
       "path": "lib/stores"
     },
     "name": "set",
-    "order": 53,
+    "order": 54,
     "params": [
       {
         "type": {
@@ -456,7 +471,7 @@
     "memberof": "module:@the-/server",
     "meta": {
       "filename": "TheServer.js",
-      "lineno": 33,
+      "lineno": 35,
       "path": "lib"
     },
     "name": "TheServer",
@@ -477,7 +492,7 @@
       "path": "lib/stores"
     },
     "name": "ConnectionStore",
-    "order": 40,
+    "order": 41,
     "scope": "static"
   },
   {
@@ -494,7 +509,7 @@
       "path": "lib/stores"
     },
     "name": "SessionStore",
-    "order": 43,
+    "order": 44,
     "scope": "static"
   },
   {
@@ -508,7 +523,7 @@
       "path": "lib/stores"
     },
     "name": "Store",
-    "order": 45,
+    "order": 46,
     "scope": "static"
   },
   {
@@ -583,7 +598,7 @@
       "path": "lib/constants"
     },
     "name": "DefaultValues",
-    "order": 16,
+    "order": 17,
     "scope": "static"
   },
   {
@@ -598,7 +613,7 @@
       "path": "lib/constants"
     },
     "name": "constants",
-    "order": 17,
+    "order": 18,
     "scope": "static"
   },
   {
@@ -614,7 +629,7 @@
       "path": "lib/helpers"
     },
     "name": "helpers",
-    "order": 24,
+    "order": 25,
     "scope": "static"
   },
   {
@@ -629,7 +644,7 @@
       "path": "lib/stores"
     },
     "name": "stores",
-    "order": 42,
+    "order": 43,
     "scope": "static"
   },
   {
@@ -791,7 +806,7 @@
       "path": "lib/helpers"
     },
     "name": "asStrictSession",
-    "order": 19,
+    "order": 20,
     "params": [
       {
         "type": {
@@ -825,7 +840,7 @@
       "path": "lib/helpers"
     },
     "name": "callbacksProxy",
-    "order": 20,
+    "order": 21,
     "params": [
       {
         "optional": true,
@@ -856,7 +871,7 @@
       "path": "lib/helpers"
     },
     "name": "ClientAccess",
-    "order": 21,
+    "order": 22,
     "params": [
       {
         "type": {
@@ -891,7 +906,7 @@
       "path": "lib/helpers"
     },
     "name": "ctxInjector",
-    "order": 23,
+    "order": 24,
     "params": [
       {
         "type": {
@@ -925,7 +940,7 @@
       "path": "lib/helpers"
     },
     "name": "InfoFlusher",
-    "order": 25,
+    "order": 26,
     "params": [
       {
         "type": {
@@ -968,7 +983,7 @@
       "path": "lib/helpers"
     },
     "name": "flushInfo",
-    "order": 27,
+    "order": 28,
     "scope": "static"
   },
   {
@@ -983,7 +998,7 @@
       "path": "lib/helpers"
     },
     "name": "langDetector",
-    "order": 28,
+    "order": 29,
     "params": [
       {
         "type": {
@@ -1031,7 +1046,7 @@
       "path": "lib/helpers"
     },
     "name": "MetricsCounter",
-    "order": 29,
+    "order": 30,
     "returns": [
       {
         "type": {
@@ -1054,7 +1069,7 @@
       "path": "lib/helpers"
     },
     "name": "queryFromUrl",
-    "order": 31,
+    "order": 32,
     "params": [
       {
         "name": "urlString"
@@ -1083,7 +1098,7 @@
       "path": "lib/helpers"
     },
     "name": "RPCKeeper",
-    "order": 32,
+    "order": 33,
     "params": [
       {
         "type": {
@@ -1118,7 +1133,7 @@
       "path": "lib/helpers"
     },
     "name": "serverRendering",
-    "order": 34,
+    "order": 35,
     "params": [
       {
         "type": {
@@ -1164,7 +1179,7 @@
       "path": "lib/helpers"
     },
     "name": "serverRendering",
-    "order": 35,
+    "order": 36,
     "params": [
       {
         "name": "Html"
@@ -1197,7 +1212,7 @@
       "path": "lib/helpers"
     },
     "name": "reload",
-    "order": 36,
+    "order": 37,
     "returns": [
       {
         "type": {
@@ -1221,7 +1236,7 @@
       "path": "lib/helpers"
     },
     "name": "save",
-    "order": 37,
+    "order": 38,
     "params": [
       {
         "type": {
@@ -1257,7 +1272,7 @@
       "path": "lib/helpers"
     },
     "name": "toControllerDriverFactory",
-    "order": 38,
+    "order": 39,
     "params": [
       {
         "name": "ControllerFactory"
@@ -1289,7 +1304,7 @@
       "path": "lib/helpers"
     },
     "name": "toLowerKeys",
-    "order": 39,
+    "order": 40,
     "params": [
       {
         "optional": true,
@@ -1319,7 +1334,7 @@
       "path": "lib/streaming"
     },
     "name": "streamPool",
-    "order": 55,
+    "order": 56,
     "returns": [
       {
         "type": {
@@ -1343,7 +1358,7 @@
       "path": "lib/streaming"
     },
     "name": "toStreamDriverFactory",
-    "order": 56,
+    "order": 57,
     "params": [
       {
         "name": "StreamFactory"
@@ -1375,7 +1390,7 @@
       "path": "lib/helpers"
     },
     "name": "clientAccess",
-    "order": 22,
+    "order": 23,
     "scope": "inner"
   },
   {
@@ -1389,7 +1404,7 @@
       "path": "lib/helpers"
     },
     "name": "infoFlusher",
-    "order": 26,
+    "order": 27,
     "scope": "inner"
   },
   {
@@ -1403,7 +1418,7 @@
       "path": "lib/helpers"
     },
     "name": "metricsCounter",
-    "order": 30,
+    "order": 31,
     "scope": "inner"
   },
   {
@@ -1417,7 +1432,7 @@
       "path": "lib/helpers"
     },
     "name": "rpcKeeper",
-    "order": 33,
+    "order": 34,
     "scope": "inner"
   },
   {
@@ -1431,7 +1446,7 @@
       "path": "lib/streaming"
     },
     "name": "StreamDriverPool",
-    "order": 54,
+    "order": 55,
     "returns": [
       {
         "type": {

--- a/packages/server/doc/api/jsdoc.json
+++ b/packages/server/doc/api/jsdoc.json
@@ -13,7 +13,7 @@
     "name": "@the-/server",
     "order": 3,
     "typicalname": "server",
-    "version": "17.7.7"
+    "version": "17.7.8"
   },
   {
     "description": "HTTP server for the-framework",

--- a/packages/server/lib/TheServer.js
+++ b/packages/server/lib/TheServer.js
@@ -11,6 +11,7 @@ const theTmp = require('@the-/tmp')
 const { redisAdapter } = require('./adapters')
 const buildInEndpoints = require('./buildInEndpoints')
 const { IOConnector } = require('./connectors')
+const { ClientStatuses } = require('./constants')
 const DefaultValues = require('./constants/DefaultValues')
 const IOEvents = require('./constants/IOEvents')
 const {
@@ -21,6 +22,7 @@ const {
   toControllerDriverFactory,
 } = require('./helpers')
 const ClientAccess = require('./helpers/ClientAccess')
+const ClientStatusPool = require('./helpers/ClientStatusPool')
 const ControllerDriverPool = require('./helpers/ControllerDriverPool')
 const InfoFlusher = require('./helpers/InfoFlusher')
 const MetricsCounter = require('./helpers/MetricsCounter')
@@ -263,6 +265,7 @@ class TheServer extends RFunc {
     this.infoFlusher = infoFlusher
     this.closeRedisAdapter = redisAdapter(io, this.redisConfig)
     const metricsCounter = MetricsCounter()
+    const clientStatusPool = ClientStatusPool()
     const controllerDriverPool = ControllerDriverPool()
     this.controllerDriverPool = controllerDriverPool
     this.metricsCounter = metricsCounter
@@ -272,6 +275,7 @@ class TheServer extends RFunc {
       connectionStore,
       encoder: this.encoder,
       onIOClientCame: async (cid, socketId, client) => {
+        clientStatusPool.init(cid, socketId)
         await clientAccess.saveClientSocket(cid, socketId, client)
         const controllerNames = Object.keys(this.ControllerDriverFactories)
         for (const controllerName of controllerNames) {
@@ -281,11 +285,21 @@ class TheServer extends RFunc {
           interceptors.controllerDidAttach()
           metricsCounter.addControllerAttachCount(controllerName, 1)
           await driver.saveSession()
+          // MEMO: ここに来なければ driver は存在しない
           controllerDriverPool.add(cid, socketId, controllerName, driver)
         }
+        clientStatusPool.ready(cid, socketId)
       },
       onIOClientGone: async (cid, socketId, reason) => {
+        const status = clientStatusPool.get(cid, socketId)
+        if (status !== ClientStatuses.READY) {
+          console.warn(
+            `[TheServer] The status of connection ${cid}@${socketId} is not ready: ${status}`,
+          )
+        }
+
         // TODO Wait until onIOClientCame done
+        clientStatusPool.finalize(cid, socketId)
         const { rpcKeeper } = this
         const hasConnection = await clientAccess.hasClientConnection(cid)
         if (!hasConnection) {
@@ -313,6 +327,7 @@ class TheServer extends RFunc {
         rpcKeeper.stopKeepTimersFor(cid)
 
         await clientAccess.removeClientSocket(cid, socketId, reason)
+        clientStatusPool.del(cid, socketId)
       },
       onRPCAbort: async () => {
         // TODO Support aborting RPC Call
@@ -322,8 +337,9 @@ class TheServer extends RFunc {
         const { iid, methodName, moduleName, params } = config
         const driver = controllerDriverPool.get(cid, socketId, moduleName)
         if (!driver) {
+          const status = clientStatusPool.get(cid, socketId)
           const error = new Error(
-            `[@the-/server] Controller not found: ${moduleName}`,
+            `[@the-/server] Controller not found. moduleName: ${moduleName}, status: ${status}`,
           )
           console.error(error)
           await this.ioConnector.sendRPCError(cid, iid, [error])

--- a/packages/server/lib/TheServer.js
+++ b/packages/server/lib/TheServer.js
@@ -285,7 +285,6 @@ class TheServer extends RFunc {
           interceptors.controllerDidAttach()
           metricsCounter.addControllerAttachCount(controllerName, 1)
           await driver.saveSession()
-          // MEMO: ここに来なければ driver は存在しない
           controllerDriverPool.add(cid, socketId, controllerName, driver)
         }
         clientStatusPool.ready(cid, socketId)

--- a/packages/server/lib/constants/ClientStatuses.js
+++ b/packages/server/lib/constants/ClientStatuses.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/**
+ * Client connection statuses
+ */
+const ClientStatuses = {
+  FINALIZING: 'status:finalizing',
+  INITIALIZING: 'status:initializing',
+  READY: 'status:ready',
+}
+
+module.exports = ClientStatuses

--- a/packages/server/lib/constants/index.js
+++ b/packages/server/lib/constants/index.js
@@ -7,14 +7,17 @@
  */
 'use strict'
 
+const ClientStatuses_ = require('./ClientStatuses')
 const DefaultValues_ = require('./DefaultValues')
 const IOEvents_ = require('./IOEvents')
 
 // `module.exports` overrides these `exports.*`, but still needs them for lebab (https://github.com/lebab/lebab)
+exports.ClientStatuses = ClientStatuses_
 exports.DefaultValues = DefaultValues_
 exports.IOEvents = IOEvents_
 
 module.exports = {
+  ClientStatuses: ClientStatuses_,
   DefaultValues: DefaultValues_,
   IOEvents: IOEvents_,
 }

--- a/packages/server/lib/helpers/ClientStatusPool.js
+++ b/packages/server/lib/helpers/ClientStatusPool.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const { ClientStatuses } = require('../constants')
+
+function ClientStatusPool() {
+  const statusHash = {}
+  const keyFor = (cid, socketId) => [cid, socketId].join('@')
+  const clientStatusPool = {
+    get length() {
+      return Object.keys(statusHash).length
+    },
+    del(cid, socketId) {
+      const key = keyFor(cid, socketId)
+      delete statusHash[key]
+    },
+    finalize(cid, socketId) {
+      const key = keyFor(cid, socketId)
+      statusHash[key] = ClientStatuses.FINALIZING
+    },
+    get(cid, socketId) {
+      const key = keyFor(cid, socketId)
+      return statusHash[key]
+    },
+    init(cid, socketId) {
+      const key = keyFor(cid, socketId)
+      if (clientStatusPool.length > 1000) {
+        console.warn(
+          `[TheServer/ClientStatusPool] WARNING! ClientStatusPool size is too large (size: ${clientStatusPool.length}). It possibly causes memory leaks.`,
+        )
+      }
+
+      statusHash[key] = ClientStatuses.INITIALIZING
+    },
+    ready(cid, socketId) {
+      const key = keyFor(cid, socketId)
+      const status = statusHash[key]
+      if (status !== ClientStatuses.INITIALIZING) {
+        console.warn(
+          `[TheServer/ClientStatusPool] WARNING! Client ${key} is not initializing`,
+        )
+      }
+
+      statusHash[key] = ClientStatuses.READY
+    },
+  }
+  return clientStatusPool
+}
+
+module.exports = ClientStatusPool

--- a/packages/server/lib/helpers/index.js
+++ b/packages/server/lib/helpers/index.js
@@ -9,6 +9,7 @@
 'use strict'
 
 const ClientAccess_ = require('./ClientAccess')
+const ClientStatusPool_ = require('./ClientStatusPool')
 const ControllerDriverPool_ = require('./ControllerDriverPool')
 const InfoFlusher_ = require('./InfoFlusher')
 const MetricsCounter_ = require('./MetricsCounter')
@@ -25,6 +26,7 @@ const toLowerKeys_ = require('./toLowerKeys')
 
 // `module.exports` overrides these `exports.*`, but still needs them for lebab (https://github.com/lebab/lebab)
 exports.ClientAccess = ClientAccess_
+exports.ClientStatusPool = ClientStatusPool_
 exports.ControllerDriverPool = ControllerDriverPool_
 exports.InfoFlusher = InfoFlusher_
 exports.MetricsCounter = MetricsCounter_
@@ -41,6 +43,7 @@ exports.toLowerKeys = toLowerKeys_
 
 module.exports = {
   ClientAccess: ClientAccess_,
+  ClientStatusPool: ClientStatusPool_,
   ControllerDriverPool: ControllerDriverPool_,
   InfoFlusher: InfoFlusher_,
   MetricsCounter: MetricsCounter_,

--- a/packages/server/lib/index.js
+++ b/packages/server/lib/index.js
@@ -5,7 +5,7 @@
  * @license MIT
  * @module @the-/server
  * @typicalname server
- * @version 17.7.7
+ * @version 17.7.8
  */
 'use strict'
 

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/server",
-  "version": "17.7.7",
+  "version": "17.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/server",
   "description": "HTTP/RPC Server of the-framework",
-  "version": "17.7.7",
+  "version": "17.7.8",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",

--- a/packages/server/test/ClientStatusPoolTest.js
+++ b/packages/server/test/ClientStatusPoolTest.js
@@ -1,0 +1,49 @@
+/**
+ * Test for ClientStatusPool.
+ * Runs with mocha.
+ */
+'use strict'
+
+const {
+  strict: { equal },
+} = require('assert')
+const { ClientStatuses } = require('../lib/constants')
+const ClientStatusPool = require('../lib/helpers/ClientStatusPool')
+
+describe('client-status-pool', () => {
+  before(() => {})
+
+  after(() => {})
+
+  it('Do test', () => {
+    const pool = ClientStatusPool()
+    const cid = 'c-01'
+    const socketId = 's-01'
+    {
+      const status = pool.get(cid, socketId)
+      equal(status, undefined)
+    }
+    {
+      pool.init(cid, socketId)
+      const status = pool.get(cid, socketId)
+      equal(status, ClientStatuses.INITIALIZING)
+    }
+    {
+      pool.ready(cid, socketId)
+      const status = pool.get(cid, socketId)
+      equal(status, ClientStatuses.READY)
+    }
+    {
+      pool.finalize(cid, socketId)
+      const status = pool.get(cid, socketId)
+      equal(status, ClientStatuses.FINALIZING)
+    }
+    {
+      pool.del(cid, socketId)
+      const status = pool.get(cid, socketId)
+      equal(status, undefined)
+    }
+  })
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
@okunishinishi 

## Overview

`[@the-/server] Controller not found: ${moduleName}` のエラーが起きたときに原因を知るために接続のステータスを追加した。

## Details

`onIOClientCame()` / `onIOClientGone()` が実行されると接続のステータスが更新されるようにして、上記エラーがどのステータスで起きたかわかるようにした。たとえば onIOClientCame() が完了する前に onRPCCall() が呼び出されたりしたら、そのことがわかる。
