### PR TITLE
@the-/server: client の接続状態が READY になるまで待つようにした

### DIFF
--- a/packages/server/doc/api/api.md
+++ b/packages/server/doc/api/api.md
@@ -29,7 +29,7 @@
 ## @the-/server
 HTTP/RPC Server of the-framework
 
-**Version**: 17.7.9  
+**Version**: 17.7.10  
 **License**: MIT  
 
 * [@the-/server](#module_@the-/server)

--- a/packages/server/doc/api/jsdoc.json
+++ b/packages/server/doc/api/jsdoc.json
@@ -13,7 +13,7 @@
     "name": "@the-/server",
     "order": 3,
     "typicalname": "server",
-    "version": "17.7.9"
+    "version": "17.7.10"
   },
   {
     "description": "HTTP server for the-framework",

--- a/packages/server/lib/TheServer.js
+++ b/packages/server/lib/TheServer.js
@@ -338,10 +338,12 @@ class TheServer extends RFunc {
         if (!driver) {
           const status = clientStatusPool.get(cid, socketId)
           const error = new Error(
-            `[@the-/server] Controller not found. moduleName: ${moduleName}, status: ${status}`,
+            `[TheServer] Controller not found. moduleName: "${moduleName}", connection status: "${status}"`,
           )
           console.error(error)
-          await this.ioConnector.sendRPCError(cid, iid, [error])
+          await this.ioConnector.sendRPCError(cid, iid, [
+            { message: error.message },
+          ])
           return
         }
 

--- a/packages/server/lib/TheServer.js
+++ b/packages/server/lib/TheServer.js
@@ -290,6 +290,7 @@ class TheServer extends RFunc {
         clientStatusPool.ready(cid, socketId)
       },
       onIOClientGone: async (cid, socketId, reason) => {
+        await clientStatusPool.waitUntilReady(cid, socketId, { maxTime: 3000 })
         const status = clientStatusPool.get(cid, socketId)
         if (status !== ClientStatuses.READY) {
           console.warn(
@@ -297,7 +298,6 @@ class TheServer extends RFunc {
           )
         }
 
-        // TODO Wait until onIOClientCame done
         clientStatusPool.finalize(cid, socketId)
         const { rpcKeeper } = this
         const hasConnection = await clientAccess.hasClientConnection(cid)
@@ -332,6 +332,7 @@ class TheServer extends RFunc {
         // TODO Support aborting RPC Call
       },
       onRPCCall: async (cid, socketId, config) => {
+        await clientStatusPool.waitUntilReady(cid, socketId, { maxTime: 3000 })
         const { rpcKeeper } = this
         const { iid, methodName, moduleName, params } = config
         const driver = controllerDriverPool.get(cid, socketId, moduleName)

--- a/packages/server/lib/helpers/ClientStatusPool.js
+++ b/packages/server/lib/helpers/ClientStatusPool.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const asleep = require('asleep')
 const { ClientStatuses } = require('../constants')
 
 function ClientStatusPool() {
@@ -41,6 +42,20 @@ function ClientStatusPool() {
       }
 
       statusHash[key] = ClientStatuses.READY
+    },
+    async waitUntilReady(cid, socketId, options) {
+      const { maxTime } = options
+      const key = keyFor(cid, socketId)
+      const interval = 100
+      let count = 1
+      while (statusHash[key] !== ClientStatuses.READY) {
+        if (count * interval > maxTime) {
+          return
+        }
+
+        await asleep(interval)
+        count++
+      }
     },
   }
   return clientStatusPool

--- a/packages/server/lib/index.js
+++ b/packages/server/lib/index.js
@@ -5,7 +5,7 @@
  * @license MIT
  * @module @the-/server
  * @typicalname server
- * @version 17.7.9
+ * @version 17.7.10
  */
 'use strict'
 

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/server",
-  "version": "17.7.8",
+  "version": "17.7.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/server",
-  "version": "17.7.9",
+  "version": "17.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/server",
   "description": "HTTP/RPC Server of the-framework",
-  "version": "17.7.9",
+  "version": "17.7.10",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",


### PR DESCRIPTION
#53 続き

onIOClientGone と onRPCCall の最初に接続状態が READY になるまで待つようにした。

これまでは Redis のレスポンスが遅かったりして初期化処理に時間がかかると READY になる前に onRPCCall が呼び出されて失敗することがあった。（たとえば clientAccess.saveClientSocket() 関数内に sleep を入れると再現する）

この修正によってその問題が解決される。