### PR TITLE
TheInputUploadのprops.valueにオブジェクトも受け付けるようにした

### DIFF
--- a/packages/ui-input/lib/TheInputUpload.jsx
+++ b/packages/ui-input/lib/TheInputUpload.jsx
@@ -215,7 +215,11 @@ TheInputUpload.propTypes = {
   /** Guide text */
   text: PropTypes.string,
   /** Value of input */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+    PropTypes.object,
+  ]),
   /** Image width */
   width: PropTypes.number,
 }

--- a/packages/ui-input/lib/helpers.jsx
+++ b/packages/ui-input/lib/helpers.jsx
@@ -71,6 +71,10 @@ export function renderWarningMessage(warning) {
 }
 
 export function isImageUrl(src) {
+  if (typeof src !== 'string') {
+    return false
+  }
+
   if (/^data:image/.test(src)) {
     return true
   }
@@ -84,6 +88,10 @@ export function isImageUrl(src) {
 }
 
 export function isVideoUrl(src) {
+  if (typeof src !== 'string') {
+    return false
+  }
+
   if (/^data:video/.test(src)) {
     return true
   }
@@ -97,6 +105,10 @@ export function isVideoUrl(src) {
 }
 
 export function isUnknownTypeUrl(src) {
+  if (typeof src !== 'string') {
+    return false
+  }
+
   if (/^data:/.test(src)) {
     return false
   }

--- a/packages/ui-input/lib/index.jsx
+++ b/packages/ui-input/lib/index.jsx
@@ -4,7 +4,7 @@
  * @description Input of the-components
  * @module @the-/ui-input
  * @typicalname uiInput
- * @version 17.1.5
+ * @version 17.1.6
  */
 'use strict'
 

--- a/packages/ui-input/package-lock.json
+++ b/packages/ui-input/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/ui-input",
-  "version": "17.1.5",
+  "version": "17.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/ui-input",
   "description": "Input of the-components",
-  "version": "17.1.5",
+  "version": "17.1.6",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",


### PR DESCRIPTION
@okunishinishi 

TheInputUpload の convertFile() 関数の返り値が props.value になる。PDF ファイルなどのアップロード時にアップロードURLだけでなくファイル名も保持しておきたいケースがある。そのために props.value がオブジェクトでも受け付けるようにした。
