### PR TITLE
ObjectScopeのresetを修正

### DIFF
--- a/packages/scope/doc/api/api.md
+++ b/packages/scope/doc/api/api.md
@@ -5,7 +5,7 @@
 ## @the-/scope
 State scope for the-store
 
-**Version**: 15.4.13  
+**Version**: 15.4.14  
 **License**: MIT  
 
 * [@the-/scope](#module_@the-/scope)

--- a/packages/scope/doc/api/jsdoc.json
+++ b/packages/scope/doc/api/jsdoc.json
@@ -13,7 +13,7 @@
     "name": "@the-/scope",
     "order": 2,
     "typicalname": "scope",
-    "version": "15.4.13"
+    "version": "15.4.14"
   },
   {
     "description": "Abstract state class",
@@ -657,7 +657,7 @@
     "memberof": "module:@the-/scope.scopes.ObjectScope",
     "meta": {
       "filename": "ObjectScope.js",
-      "lineno": 68,
+      "lineno": 69,
       "path": "lib/scopes"
     },
     "name": "set",
@@ -692,7 +692,7 @@
     "memberof": "ObjectScope",
     "meta": {
       "filename": "ObjectScope.js",
-      "lineno": 97,
+      "lineno": 98,
       "path": "lib/scopes"
     },
     "name": "get",
@@ -708,7 +708,7 @@
     "memberof": "ObjectScope",
     "meta": {
       "filename": "ObjectScope.js",
-      "lineno": 102,
+      "lineno": 103,
       "path": "lib/scopes"
     },
     "name": "has",

--- a/packages/scope/lib/scopes/ObjectScope.js
+++ b/packages/scope/lib/scopes/ObjectScope.js
@@ -55,9 +55,10 @@ class ObjectScope extends Scope {
        */
       reset(values = {}) {
         return (state) => {
-          const needsSet = Object.keys(values || {}).some(
-            (name) => values[name] !== state[name],
-          )
+          const needsSet = [
+            ...Object.keys(values || {}),
+            ...Object.keys(state || {}),
+          ].some((name) => values[name] !== state[name])
           if (!needsSet) {
             return state
           }

--- a/packages/scope/package-lock.json
+++ b/packages/scope/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/scope",
-  "version": "15.4.13",
+  "version": "15.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,7 +28,7 @@
         "asobj": "^3.0.1",
         "bredux": "^3.0.7",
         "bwindow": "^2.0.3",
-        "json-pointer": "^0.6.0",
+        "json-pointer": "^0.6.1",
         "objnest": "^5.0.10",
         "redux": "^4.0.5"
       },

--- a/packages/scope/test/ObjectScopeTest.js
+++ b/packages/scope/test/ObjectScopeTest.js
@@ -47,6 +47,13 @@ describe('object-scope', () => {
 
     store.foo.reset({ x: 1, y: 2 })
     deepEqual(store.foo.state, { x: 1, y: 2 })
+
+    store.foo.reset({ x: 1, y: 2, z: 3 })
+    deepEqual(store.foo.state, { x: 1, y: 2, z: 3 })
+
+    store.foo.reset({ x: 1 })
+    deepEqual(store.foo.state, { x: 1 })
+
     store.foo.drop()
 
     deepEqual(store.foo.state, {})


### PR DESCRIPTION
ObjectScopeのresetで`state = { x:1, y:2 }`, `values = { x:1 }`のように要素を減らした場合に、
差分判定がvaluesのkeyのみしか参照しない影響でstateが更新されないバグを修正した。
