### PR TITLE
Fix ui-map

### DIFF
--- a/packages/ui-map/doc/api/api.md
+++ b/packages/ui-map/doc/api/api.md
@@ -30,7 +30,7 @@
 ## @the-/ui-map
 Geo map for the-components
 
-**Version**: 16.4.5  
+**Version**: 16.4.6  
 <a name="DivIcon"></a>
 
 ## DivIcon ⇐ <code>L.DivIcon</code>

--- a/packages/ui-map/doc/api/jsdoc.json
+++ b/packages/ui-map/doc/api/jsdoc.json
@@ -12,7 +12,7 @@
     "name": "@the-/ui-map",
     "order": 0,
     "typicalname": "uiMap",
-    "version": "16.4.5"
+    "version": "16.4.6"
   },
   {
     "augments": [
@@ -69,7 +69,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 252,
+      "lineno": 256,
       "path": "lib"
     },
     "name": "TileLayerClass",
@@ -84,7 +84,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 254,
+      "lineno": 258,
       "path": "lib"
     },
     "name": "draggingEnabled",
@@ -99,7 +99,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 256,
+      "lineno": 260,
       "path": "lib"
     },
     "name": "freezed",
@@ -114,7 +114,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 258,
+      "lineno": 262,
       "path": "lib"
     },
     "name": "height",
@@ -129,7 +129,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 260,
+      "lineno": 264,
       "path": "lib"
     },
     "name": "lat",
@@ -144,7 +144,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 262,
+      "lineno": 266,
       "path": "lib"
     },
     "name": "lng",
@@ -159,7 +159,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 264,
+      "lineno": 268,
       "path": "lib"
     },
     "name": "onLeafletMap",
@@ -174,7 +174,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 266,
+      "lineno": 270,
       "path": "lib"
     },
     "name": "polylines",
@@ -189,7 +189,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 268,
+      "lineno": 272,
       "path": "lib"
     },
     "name": "spinning",
@@ -204,7 +204,7 @@
     "memberof": "TheMap.propTypes",
     "meta": {
       "filename": "TheMap.jsx",
-      "lineno": 270,
+      "lineno": 274,
       "path": "lib"
     },
     "name": "width",

--- a/packages/ui-map/lib/TheMap.jsx
+++ b/packages/ui-map/lib/TheMap.jsx
@@ -214,6 +214,10 @@ const TheMap = React.memo((props) => {
 
     const { current: mapElm } = mapElmRef
     const unobserve = observeResize(mapElm, () => {
+      if (mapAccess.state.gone) {
+        return
+      }
+
       mapAccess.invalidate()
     })
     return unobserve

--- a/packages/ui-map/lib/helpers/MapAccess.jsx
+++ b/packages/ui-map/lib/helpers/MapAccess.jsx
@@ -9,6 +9,7 @@ const nullOrUndefined = (v) => v === null || typeof v === 'undefined'
 
 function MapAccess(map, { TileLayerClass }) {
   const state = {
+    gone: false,
     layerControl: null,
     layers: {},
     markers: {},
@@ -140,6 +141,7 @@ function MapAccess(map, { TileLayerClass }) {
     cleanup() {
       state.layers = {}
       state.markers = {}
+      state.gone = true
       map.remove()
     },
     createLayer({ title, ...options } = {}) {

--- a/packages/ui-map/package-lock.json
+++ b/packages/ui-map/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/ui-map",
-  "version": "16.4.4",
+  "version": "16.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1052,26 +1052,24 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.1"
       }
     },
     "react-is": {
@@ -1141,9 +1139,9 @@
       }
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/packages/ui-map/package-lock.json
+++ b/packages/ui-map/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-/ui-map",
-  "version": "16.4.5",
+  "version": "16.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui-map/package.json
+++ b/packages/ui-map/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@the-/ui-map",
   "description": "Geo map for the-components",
-  "version": "16.4.5",
+  "version": "16.4.6",
   "author": {
     "email": "okunishinishi@gmail.com",
     "name": "Taka Okunishi",

--- a/packages/ui-map/package.json
+++ b/packages/ui-map/package.json
@@ -31,8 +31,8 @@
     "coz": "^7.2.1",
     "leaflet": "^1.7.1",
     "objnest": "^5.0.10",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"
   },
   "engines": {


### PR DESCRIPTION
@okunishinishi 

React 17 以降で TheMap コンポーネントが unmount されるときに以下のようなエラーが発生するようになった。

> Uncaught TypeError: Cannot read property '_leaflet_pos' of undefined

原因はおそらく微妙にコンポーネントのライフサイクルが変わったためで、map が cleanup されたあとに `map.invalidateSize()` が呼ばれることがある。

そこで、mapAccess.invalidate() を呼ぶ前に map が cleanup 済かどうかをチェックするようにした。