### PR TITLE
driver-sequelizeのparseFilterの$andのケースを修正

### DIFF
--- a/packages/driver-sequelize/lib/parsing/parseFilter.js
+++ b/packages/driver-sequelize/lib/parsing/parseFilter.js
@@ -40,9 +40,14 @@ function parseFilter(filter, options = {}) {
   }
 
   if (filter.$and) {
+    // Example:
+    // {$and: [{ foo: {$like: '%a%'} }, {foo: {$like: '%b%'}}]}
+    // -> { [Op.and]: [{ foo: {[Op.like]: '%a%'} }, {foo: {[Op.like]: '%b%'}}] }
     const { $and, ...rest } = filter
-    const andArray = $and.map((and) => ({ ...and, ...rest }))
-    return parseFilter(Object.assign({}, ...andArray), options)
+    const andArray = $and
+      .map((and) => ({ ...and, ...rest }))
+      .map((filter) => parseFilter(filter, options))
+    return { [Op.and]: andArray }
   }
 
   const parsed = {}


### PR DESCRIPTION
https://github.com/realglobe-Inc/hec-eye/pull/5585 で レポート管理画面の検索でタグで絞り込みができる機能を実装したところ下のように紐づいていないタグも含め絞り込んでるのに検索に引っかかる不具合が発生したので、その修正です。

<img width="720" alt="スクリーンショット 2021-02-18 17 02 59" src="https://user-images.githubusercontent.com/13880890/108324405-37b8d980-720b-11eb-9bc1-59c07e237fd1.png">



`{$and: [ {a: 'bcd'}, {a: 'ecd'} ]}` のような場合に key がまとめられてしまっていたのが原因だったので修正しました。