### PR TITLE
Fix TheInputUpload

### DIFF
--- a/packages/ui-input/lib/TheInputUpload.jsx
+++ b/packages/ui-input/lib/TheInputUpload.jsx
@@ -153,6 +153,8 @@ const TheInputUpload = React.memo((props) => {
         style={readOnly && !hasImage ? {} : { height, width }}
         tabIndex={-1}
         type='file'
+        // Set empty string to clear files in the input
+        value={urls.length === 0 ? '' : undefined}
       />
       <TheCondition unless={readOnly}>
         <TheInputUploadLabel

--- a/packages/ui-input/lib/TheInputUpload.jsx
+++ b/packages/ui-input/lib/TheInputUpload.jsx
@@ -111,6 +111,7 @@ const TheInputUpload = React.memo((props) => {
           onLoad && onLoad({ target, urls })
           onUpdate && onUpdate({ [name]: multiple ? urls : urls[0] })
           setUrls(urls)
+          setError(null)
         } catch (error) {
           setUrls([])
           handleError(error)


### PR DESCRIPTION
修正2点

- 「ファイル選択 → convertFile でエラー → 再びファイル選択」をしたときにエラーメッセージが残る問題を修正
  - ファイル選択に成功したらエラーメッセージをクリアするようにした
- 「ファイル選択 → ✗ボタンでキャンセル → 再び同じファイルを選択」をしたときに input 要素の change イベントが発火しない問題を修正
  - ✗ボタンでキャンセルした場合、Component の state は変わるが input 要素内部の files は変更がなく、そのため同じファイルを選択すると「fileList に変更なし」扱いになる
  - input 要素の values に空文字を入れると input 要素内部の files をリセットできるので、そのように修正した